### PR TITLE
Update Prom Bolt Metrics Collector

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,20 +4,20 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "dbf5a9ef855684f84cac2e7ae7886c5a001d4f66ae23f6904da0faaaef0d61fc",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.2/rules_go-v0.22.2.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.2/rules_go-v0.22.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.11/rules_go-v0.24.11.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.11/rules_go-v0.24.11.tar.gz",
     ],
-    sha256 = "142dd33e38b563605f0d20e89d9ef9eda0fc3cb539a14be1bdb1350de2eda659",
 )
 
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "1f4fc1d91826ec436ae04833430626f4cc02c20bb0a813c0c2f3c4c421307b1d",
+    strip_prefix = "bazel-gazelle-e368a11b76e92932122d824970dc0ce5feb9c349",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.20.0/bazel-gazelle-v0.20.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.20.0/bazel-gazelle-v0.20.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/archive/e368a11b76e92932122d824970dc0ce5feb9c349.tar.gz",
     ],
-    sha256 = "d8c45ee70ec39a57e7a05e5027c32b1576cc7f16d9dd37135b0eddde45cf1b10",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -34,9 +34,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "com_google_protobuf",
-    commit = "09745575a923640154bcf307fba8aedff47f240a",
+    commit = "fde7cf7358ec7cd69e8db9be4f1fa6a5c431386a",  # v3.13.0
     remote = "https://github.com/protocolbuffers/protobuf",
-    shallow_since = "1558721209 -0700",
+    shallow_since = "1597443653 -0700",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/bucketstatscollector_test.go
+++ b/bucketstatscollector_test.go
@@ -4,15 +4,17 @@ import (
 	"strings"
 	"testing"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/prometheus/client_golang/prometheus"
+	bolt "go.etcd.io/bbolt"
 )
 
 func TestBucketStatsCollector(t *testing.T) {
 	tests := []struct {
-		name    string
-		s       []memoryBucketStats
-		matches []string
+		name           string
+		s              []memoryBucketStats
+		matches        []string
+		noMatches      []string
+		blockedBuckets [][]byte
 	}{
 		{
 			name: "single bucket",
@@ -119,16 +121,95 @@ func TestBucketStatsCollector(t *testing.T) {
 				`bolt_bucket_inlined_buckets_in_use_bytes{bucket="bar",database="test.db"} 13`,
 			},
 		},
+		{
+			name: "banned buckets",
+			s: []memoryBucketStats{
+				{
+					name: "foo",
+					s: bolt.BucketStats{
+						BranchPageN:       1,
+						BranchOverflowN:   2,
+						LeafPageN:         3,
+						LeafOverflowN:     4,
+						KeyN:              5,
+						Depth:             6,
+						BranchAlloc:       7,
+						BranchInuse:       8,
+						LeafAlloc:         9,
+						LeafInuse:         10,
+						BucketN:           11,
+						InlineBucketN:     12,
+						InlineBucketInuse: 13,
+					},
+				},
+				{
+					name: "bar",
+					s: bolt.BucketStats{
+						BranchPageN:       1,
+						BranchOverflowN:   2,
+						LeafPageN:         3,
+						LeafOverflowN:     4,
+						KeyN:              5,
+						Depth:             6,
+						BranchAlloc:       7,
+						BranchInuse:       8,
+						LeafAlloc:         9,
+						LeafInuse:         10,
+						BucketN:           11,
+						InlineBucketN:     12,
+						InlineBucketInuse: 13,
+					},
+				},
+			},
+			blockedBuckets: [][]byte{[]byte("bar")},
+			matches: []string{
+				`bolt_bucket_logical_branch_pages{bucket="foo",database="test.db"} 1`,
+				`bolt_bucket_physical_branch_overflow_pages{bucket="foo",database="test.db"} 2`,
+				`bolt_bucket_logical_leaf_pages{bucket="foo",database="test.db"} 3`,
+				`bolt_bucket_physical_leaf_overflow_pages{bucket="foo",database="test.db"} 4`,
+				`bolt_bucket_keys{bucket="foo",database="test.db"} 5`,
+				`bolt_bucket_depth{bucket="foo",database="test.db"} 6`,
+				`bolt_bucket_physical_branch_pages_allocated_bytes{bucket="foo",database="test.db"} 7`,
+				`bolt_bucket_physical_branch_pages_in_use_bytes{bucket="foo",database="test.db"} 8`,
+				`bolt_bucket_physical_leaf_pages_allocated_bytes{bucket="foo",database="test.db"} 9`,
+				`bolt_bucket_physical_leaf_pages_in_use_bytes{bucket="foo",database="test.db"} 10`,
+				`bolt_bucket_buckets{bucket="foo",database="test.db"} 11`,
+				`bolt_bucket_inlined_buckets{bucket="foo",database="test.db"} 12`,
+				`bolt_bucket_inlined_buckets_in_use_bytes{bucket="foo",database="test.db"} 13`,
+			},
+			noMatches: []string{
+				`bolt_bucket_logical_branch_pages{bucket="bar",database="test.db"} 1`,
+				`bolt_bucket_physical_branch_overflow_pages{bucket="bar",database="test.db"} 2`,
+				`bolt_bucket_logical_leaf_pages{bucket="bar",database="test.db"} 3`,
+				`bolt_bucket_physical_leaf_overflow_pages{bucket="bar",database="test.db"} 4`,
+				`bolt_bucket_keys{bucket="bar",database="test.db"} 5`,
+				`bolt_bucket_depth{bucket="bar",database="test.db"} 6`,
+				`bolt_bucket_physical_branch_pages_allocated_bytes{bucket="bar",database="test.db"} 7`,
+				`bolt_bucket_physical_branch_pages_in_use_bytes{bucket="bar",database="test.db"} 8`,
+				`bolt_bucket_physical_leaf_pages_allocated_bytes{bucket="bar",database="test.db"} 9`,
+				`bolt_bucket_physical_leaf_pages_in_use_bytes{bucket="bar",database="test.db"} 10`,
+				`bolt_bucket_buckets{bucket="bar",database="test.db"} 11`,
+				`bolt_bucket_inlined_buckets{bucket="bar",database="test.db"} 12`,
+				`bolt_bucket_inlined_buckets_in_use_bytes{bucket="bar",database="test.db"} 13`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := testCollector(t, newMemoryBucketStatsCollector(tt.s))
+			got := testCollector(t, newMemoryBucketStatsCollector(tt.s, tt.blockedBuckets...))
 
 			for _, m := range tt.matches {
 				t.Run(m, func(t *testing.T) {
 					if !strings.Contains(got, m) {
 						t.Fatalf("output did not contain expected metric: %q", m)
+					}
+				})
+			}
+			for _, m := range tt.noMatches {
+				t.Run(m, func(t *testing.T) {
+					if strings.Contains(got, m) {
+						t.Fatalf("output contains unexpected metric: %q", m)
 					}
 				})
 			}
@@ -141,11 +222,13 @@ type memoryBucketStats struct {
 	s    bolt.BucketStats
 }
 
-func newMemoryBucketStatsCollector(stats []memoryBucketStats) prometheus.Collector {
-	bs := newBucketStatsCollector("test.db", nil)
-
-	bs.forEach = func(fn forEachBucketStatsFunc) error {
+func newMemoryBucketStatsCollector(stats []memoryBucketStats, blockedBuckets ...[]byte) prometheus.Collector {
+	bs := newBucketStatsCollector("test.db", nil, blockedBuckets...)
+	bs.forEach = func(bn bucketValidityChecker, fn forEachBucketStatsFunc) error {
 		for _, s := range stats {
+			if !bn(s.name) {
+				continue
+			}
 			if err := fn(s.name, s.s); err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prysmaticlabs/prombbolt
 
-go 1.13
+go 1.15
 
 require (
 	github.com/prometheus/client_golang v1.5.1

--- a/prombolt.go
+++ b/prombolt.go
@@ -4,8 +4,8 @@ package prombolt
 import (
 	"sync"
 
-	bolt "go.etcd.io/bbolt"
 	"github.com/prometheus/client_golang/prometheus"
+	bolt "go.etcd.io/bbolt"
 )
 
 const (
@@ -18,10 +18,10 @@ const (
 //
 // Name should specify a unique name for the collector, and will be added
 // as a label to all produced Prometheus metrics.
-func New(name string, db *bolt.DB) prometheus.Collector {
+func New(name string, db *bolt.DB, blockedBuckets ...[]byte) prometheus.Collector {
 	return &collector{
 		stats:       newStatsCollector(name, db),
-		bucketStats: newBucketStatsCollector(name, db),
+		bucketStats: newBucketStatsCollector(name, db, blockedBuckets...),
 	}
 }
 


### PR DESCRIPTION
For an in-depth background for why it is required:
https://github.com/prysmaticlabs/prysm/issues/8274

- [x] Adds in an argument to allow blocking buckets from which metrics are not required
- [x] Adds in test case for blocking of bucket.
- [x] Updates dependencies to be up to date with latest go version and bazel version.
